### PR TITLE
Enable the option to resize Actor and Monster sheets

### DIFF
--- a/src/less/actor-sheet.less
+++ b/src/less/actor-sheet.less
@@ -1,5 +1,8 @@
 .character,
 .monster {
+  min-width: 630px;
+  min-height: 625px;
+
   .sheet-header {
     overflow: hidden;
     margin-bottom: 10px;

--- a/src/less/actor-sheet.less
+++ b/src/less/actor-sheet.less
@@ -58,6 +58,40 @@
       }
     }
   }
+
+
+  .sheet-content {
+    height: 100%;
+    .tab {
+      height: 100%;
+    }
+    label {
+      display: block;
+      margin-bottom: 5px;
+    }
+    .editor {
+      height: calc(100% - 20px);
+      border: 1px solid #aaa;
+    }
+    .full-width-field {
+      margin-bottom: 10px;
+      input,
+      select {
+        width: 100%;
+      }
+    }
+    .full-height-field {
+      height: 100%;
+    }
+    .item-control {
+      .active {
+        color: rgb(25, 24, 19);
+      }
+      .inactive {
+        color: rgba(0, 0, 0, 0.4);
+      }
+    }
+  }
 }
 
 .character {
@@ -65,7 +99,7 @@
     flex: 0 0 215px;
   }
   .actor-notes {
-    height: 250px;
+    height: calc(100% - 4em);
   }
 }
 .monster {

--- a/src/less/actor-sheet.less
+++ b/src/less/actor-sheet.less
@@ -76,7 +76,7 @@
     }
   }
   .actor-notes {
-    height: 175px;
+    height: calc(100% - 4em);
   }
 }
 

--- a/src/less/item-sheet.less
+++ b/src/less/item-sheet.less
@@ -16,35 +16,36 @@
       overflow-y: unset;
       overflow-x: unset;
     }
-  }
-  .sheet-content {
-    height: 100%;
-    display: flex;
-    label {
-      display: block;
-      margin-bottom: 5px;
-    }
-    flex-direction: column;
-    .editor {
-      height: calc(100% - 20px);
-      border: 1px solid #aaa;
-    }
-    .full-width-field {
-      margin-bottom: 10px;
-      input,
-      select {
-        width: 100%;
-      }
-    }
-    .full-height-field {
+
+    .sheet-content {
       height: 100%;
-    }
-    .item-control {
-      .active {
-        color: rgb(25, 24, 19);
+      display: flex;
+      label {
+        display: block;
+        margin-bottom: 5px;
       }
-      .inactive {
-        color: rgba(0, 0, 0, 0.4);
+      flex-direction: column;
+      .editor {
+        height: calc(100% - 20px);
+        border: 1px solid #aaa;
+      }
+      .full-width-field {
+        margin-bottom: 10px;
+        input,
+        select {
+          width: 100%;
+        }
+      }
+      .full-height-field {
+        height: 100%;
+      }
+      .item-control {
+        .active {
+          color: rgb(25, 24, 19);
+        }
+        .inactive {
+          color: rgba(0, 0, 0, 0.4);
+        }
       }
     }
   }

--- a/src/less/partials/forms.less
+++ b/src/less/partials/forms.less
@@ -73,7 +73,7 @@
   }
 
   nav.sheet-tabs {
-    height: auto;
+    max-height: 2.5em;
     border: hidden;
     background-color: rgba(0, 0, 0, 0.1);
     padding: 0;

--- a/src/less/partials/forms.less
+++ b/src/less/partials/forms.less
@@ -73,6 +73,7 @@
   }
 
   nav.sheet-tabs {
+    min-height: 2.5em;
     max-height: 2.5em;
     border: hidden;
     background-color: rgba(0, 0, 0, 0.1);

--- a/src/less/partials/mixins.less
+++ b/src/less/partials/mixins.less
@@ -1,5 +1,5 @@
 .item-image {
-  width: @item-image-width;
+  width: min-content;
   min-width: @item-image-min-width;
   text-align: center;
 }
@@ -10,12 +10,12 @@
     width: @column-width;
     min-width: @column-min-width;
     &.item-controls {
-      width: @item-controls-width;
+      width: min-content;
       min-width: @item-controls-min-width;
       text-align: center;
     }
     &.item-image {
-      width: @item-image-width;
+      width: min-content;
       min-width: @item-image-min-width;
     }
     &.align-left {

--- a/src/less/partials/table.less
+++ b/src/less/partials/table.less
@@ -9,8 +9,7 @@
   tbody {
     display: block;
     width: 100%;
-    overflow: auto;
-    height: 280px;
+    height: 100%;
   }
 
   thead {

--- a/src/less/partials/table.less
+++ b/src/less/partials/table.less
@@ -53,7 +53,7 @@
 .abilities .fixed_header {
   .fixed_header_styles(45%, 262px);
   .ability-name {
-    width: 53%;
+    width: 100%;
     min-width: 310px;
   }
   .ability-type {
@@ -69,7 +69,7 @@
 .gear .fixed_header {
   .fixed_header_styles(40%, 232px);
   .gear-name {
-    width: 44%;
+    width: 100%;
     min-width: 250px;
   }
   .gear-weight {
@@ -85,7 +85,7 @@
 .weapons .fixed_header {
   .fixed_header_styles(10%, 60px);
   .weapon-name {
-    width: 29%;
+    width: 100%;
     min-width: 160px;
   }
   .weapon-damage {
@@ -97,7 +97,7 @@
 .armour .fixed_header {
   .fixed_header_styles(21%, 120px);
   .armour-name {
-    width: 50%;
+    width: 100%;
     min-width: 290px;
   }
 }

--- a/src/less/partials/variables.less
+++ b/src/less/partials/variables.less
@@ -3,8 +3,6 @@
 @c-grey: #ddd;
 @input-height: 26px;
 @big-input-height: 32px;
-@item-controls-width: 10%;
 @item-controls-min-width: 60px;
-@item-image-width: 6%;
 @item-image-min-width: 34px;
 @wh-readonly: #e9e9e3;

--- a/src/module/constants.js
+++ b/src/module/constants.js
@@ -56,3 +56,7 @@ export const SUCCESS = "success";
 export const FAIL = "fail";
 export const WHBACKGROUND = "whBackground";
 export const DEFAULTBACKGROUND = "defaultBackground";
+
+// Sheet Constants
+export const CHARACTER_SHEET_WIDTH = 630;
+export const CHARACTER_SHEET_HEIGHT = 625;

--- a/src/module/constants.js
+++ b/src/module/constants.js
@@ -60,3 +60,5 @@ export const DEFAULTBACKGROUND = "defaultBackground";
 // Sheet Constants
 export const CHARACTER_SHEET_WIDTH = 630;
 export const CHARACTER_SHEET_HEIGHT = 625;
+export const MONSTER_SHEET_WIDTH = 600;
+export const MONSTER_SHEET_HEIGHT = 450;

--- a/src/module/sheets/WH3CharacterSheet.js
+++ b/src/module/sheets/WH3CharacterSheet.js
@@ -7,10 +7,10 @@ export default class WH3CharacterSheet extends ActorSheet {
     return mergeObject(super.defaultOptions, {
       template: "systems/whitehack3e/templates/sheets/character-sheet.hbs",
       classes: ["wh3e", "sheet", "character"],
-      width: 630,
-      height: 625,
+      width: c.CHARACTER_SHEET_WIDTH,
+      height: c.CHARACTER_SHEET_HEIGHT,
       tabs: [{ navSelector: ".sheet-tabs", contentSelector: ".sheet-content", initial: "attributes" }],
-      resizable: false,
+      resizable: true,
       dragDrop: [{ dragSelector: ".item-list .item", dropSelector: null }],
     });
   }

--- a/src/module/sheets/WH3MonsterSheet.js
+++ b/src/module/sheets/WH3MonsterSheet.js
@@ -6,9 +6,9 @@ export default class WH3MonsterSheet extends ActorSheet {
     return mergeObject(super.defaultOptions, {
       template: "systems/whitehack3e/templates/sheets/monster-sheet.hbs",
       classes: ["wh3e", "sheet", "monster"],
-      width: 600,
-      height: 450,
-      resizable: false,
+      width: c.MONSTER_SHEET_WIDTH,
+      height: c.MONSTER_SHEET_HEIGHT,
+      resizable: true,
     });
   }
 


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/5934283/156310336-4ff2414a-9871-418b-8750-a0caee290069.png)

Hi! I started an OSR game with Whitehack3e as a base and am thinking about tinkering my own Foundry system / OSR Hack. I wanted to get some practice first with a well designed system to learn the tools and best practices, so I decided to tweak some CSS.

I'm not sure if resizing is desired for your system or if the fixed size windows was a purposeful decision, but in my opinion flexible windows helps people who need to support different font sizes and supports the totally infrequent use case where players hoard every item possible under the sun and want to expand their sheet to view more at once. Plus, the notes field is soooo small by default, so resizing the sheet makes editing that text more natural.

Summary of changes:

* Adds a `gulp deploy` command to quickly copy the Whitehack3e build output to a local install of FoundryVTT for development testing. This could be cherrypicked and removed if desired or updated to support non-Linux platform install directories.
* Adds `resizable: true` to the Javascript ActorSheet and MonsterSheet classes.
* Updates the CSS of the ActorSheet `fixed_header` elements which make up the table header entries for Gear, Armor, Weapon etc. tabs. The change `*-name { width: 100% }` enables the Name field to expand to fill the space. The change `item-* { width: min-content }` makes the icon columns on the left and right of each table the minimum width possible regardless of sheet width.
* Moves default Monster and Actor sheet size magic constants to the Javascript constants file.
* Updates the tabs on the ActorSheet behavior to have a fixed height instead of a flexible one.
* Updates the table body to extend fully and enable scrolling the ActorSheet to view more entries.

TODO:
The Notes editor box doesn't resize properly yet, so there's still more work to do. Still, comments are appreciated!